### PR TITLE
Fix the Visual Studio solution not building after a fresh clone.

### DIFF
--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -1,0 +1,13 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyCompany("The Git Development Community")]
+[assembly: AssemblyCopyright("Copyright © 2009 The GitSharp Team")]
+[assembly: ComVisible(false)]
+
+#if DEBUG
+[assembly: AssemblyConfiguration("Debug")]
+#else
+[assembly: AssemblyConfiguration("Release")]
+#endif


### PR DESCRIPTION
When someone clones the repository and wants to compile the
master branch (up to the latest commit fed9535519a1a918ed6734001b7f5c3a83dd8a10),
the solution will not compile because of a missing SharedAssemblyInfo.cs

This file was deleted in commit e5dfc7643a22e997cb993132eef65c4a19d1bc35.

I simply retrieved the file from a commit just before that and added it
again.

Now everyone can clone the repository and compile the solution without
running into compilation errors.
