### PR TITLE
Fixed bug with KeyNotFoundException when resolving identity file.

### DIFF
--- a/GitSharp.Core/Transport/SshConfigSessionFactory.cs
+++ b/GitSharp.Core/Transport/SshConfigSessionFactory.cs
@@ -131,8 +131,8 @@ namespace GitSharp.Core.Transport
                 return def;
 
             string identityKey = identityFile.FullName;
-            JSch jsch = _byIdentityFile[identityKey];
-            if (jsch == null)
+            JSch jsch;
+            if(!_byIdentityFile.TryGetValue(identityKey, out jsch))
             {
                 jsch = new JSch();
                 jsch.setHostKeyRepository(def.getHostKeyRepository());


### PR DESCRIPTION
Accessing dictionary with unexisting key will throw KeyNotFoundException.
