### PR TITLE
Small correction of little misprint in Readme.txt

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -77,5 +77,5 @@ C based implementation can be obtained from the GIT websites:
   http://git-scm.com/ 
   http://progit.org/book/ - free book about Git
 
-More information about the Java implemetation which Git# stems from:
+More information about the Java implemetation which Git# steps from:
   hhttp://www.eclipse.org/jgit


### PR DESCRIPTION
There was "git# steMs from:" instead of "git# stePs from:".
